### PR TITLE
Dqr

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -137,3 +137,10 @@
 - Fix when applying tolerances with column names that contain strings
 - When applying 'output_not_applicable' the results now contain the indices of the rows to which a rule does not apply
 - Added match logical operator to check if column that contains strings satisfies a regular expression
+
+### 0.2.6 (2024-11-12)
+
+- Better fix when applying tolerances with column names that contain strings
+- Tolerances are not applied to columns where dtype is string, bool or datetime64_ns
+- Logging 'finished' with rule_id per rule_id
+- Fix for data DataFrames that contain 'pd.libs.missing.NAType()'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ruleminer"
-version = "0.2.5"
+version = "0.2.6"
 description = "Python package to mine association rules in datasets"
 authors = ["Willem Jan Willemse <w.j.willemse@freedom.nl>"]
 license = "MIT/X"

--- a/ruleminer/ruleminer.py
+++ b/ruleminer/ruleminer.py
@@ -79,8 +79,6 @@ class RuleMiner:
         params: dict = None,
     ) -> None:
         """ """
-        logger = logging.getLogger(__name__)
-
         if params is not None:
             self.params = params
         self.metrics = self.params.get(
@@ -120,6 +118,8 @@ class RuleMiner:
         if self.tolerance is not None:
 
             def __tol__(value, column=None):
+                if pd.isna(value):
+                    return np.nan
                 for key, tol in self.tolerance.items():
                     if key == column:
                         for ((start, end)), decimals in tol.items():
@@ -135,8 +135,6 @@ class RuleMiner:
         if rules is not None:
             self.rules = rules
             self.evaluate()
-
-        logger.info("Finished")
 
         return None
 
@@ -161,6 +159,7 @@ class RuleMiner:
         data: pd.DataFrame = None,
     ) -> pd.DataFrame:
         """ """
+        logger = logging.getLogger(__name__)
         if data is not None:
             self.update(data=data)
 
@@ -230,6 +229,8 @@ class RuleMiner:
                     }
                 )
                 self.results = pl.DataFrame(data)
+
+            logger.info("Finished rule_id " + str(self.rules.loc[idx, RULE_ID]))
 
         # remove temporarily added index columns
         for level in range(len(self.data.index.names)):


### PR DESCRIPTION
0.2.6 (2024-11-12)
Better fix when applying tolerances with column names that contain strings
Tolerances are not applied to columns where dtype is string, bool or datetime64_ns
Logging 'finished' with rule_id per rule_id
Fix for data DataFrames that contain 'pd.libs.missing.NAType()'